### PR TITLE
[AEGIS-27] added stat records for the split

### DIFF
--- a/src/database/shared.ts
+++ b/src/database/shared.ts
@@ -1,4 +1,5 @@
 export * from './shared/base.js';
+export * from './shared/consts.js';
 export * from './shared/helpers.js';
 export * from './shared/types.js';
 export * from './shared/zod.js';

--- a/src/database/shared/consts.ts
+++ b/src/database/shared/consts.ts
@@ -1,0 +1,1 @@
+export const RECORD_LIMIT = 10;

--- a/src/database/tables/leagueGames/leagueGames.schema.ts
+++ b/src/database/tables/leagueGames/leagueGames.schema.ts
@@ -20,7 +20,7 @@ import {
 
 export const leagueGameRowSchema = z.strictObject({
   leagueMatchId: z.uuid().nullable(),
-  invalidated: z.coerce.boolean().nullable(),
+  invalidated: z.coerce.boolean().default(false),
   patch: z.string().nullable(),
   blueTeamId: z.uuid().nullable(),
   redTeamId: z.uuid().nullable(),

--- a/src/database/tables/playerStats/playerStats.query.ts
+++ b/src/database/tables/playerStats/playerStats.query.ts
@@ -1,10 +1,61 @@
-import { PLAYER_STATS, RIOT_ACCOUNTS, USERS } from '@/database/const.js';
+import { sql } from 'kysely';
+
+import {
+  LEAGUE_GAMES,
+  LEAGUE_MATCHES,
+  PLAYER_STATS,
+  RIOT_ACCOUNTS,
+  TEAMS,
+  USERS,
+} from '@/database/const.js';
 import { db } from '@/database/database.js';
 import {
   type InsertPlayerStat,
   type PlayerStatRow,
 } from '@/database/schema.js';
+import { RECORD_LIMIT } from '@/database/shared.js';
 import type { GamePlayerStatRow } from '@/router/game/v1/game.dto.js';
+import type {
+  PlayerStatRecordCreepScorePerMinuteDto,
+  PlayerStatRecordCsAt15Dto,
+  PlayerStatRecordDamageAt15Dto,
+  PlayerStatRecordDamageDealtPerMinuteDto,
+  PlayerStatRecordGoldAt15Dto,
+  PlayerStatRecordKillsAt15Dto,
+  PlayerStatRecordVisionScorePerMinuteDto,
+} from '@/router/split/v1/split.dto.js';
+
+/**
+ * Helper function to build the base query for player stat records (used in multiple places).
+ */
+const playerStatRecordBaseQuery = (splitId: string) => {
+  return db
+    .selectFrom(`${PLAYER_STATS} as ps`)
+    .innerJoin(`${LEAGUE_GAMES} as g`, 'g.id', 'ps.leagueGameId')
+    .innerJoin(`${LEAGUE_MATCHES} as m`, 'm.id', 'g.leagueMatchId')
+    .leftJoin(`${RIOT_ACCOUNTS} as ra`, 'ra.riotPuuid', 'ps.riotPuuid')
+    .leftJoin(`${USERS} as u`, 'u.id', 'ra.userId')
+    .leftJoin(`${TEAMS} as tb`, 'tb.id', 'g.blueTeamId')
+    .leftJoin(`${TEAMS} as tr`, 'tr.id', 'g.redTeamId')
+    .where('m.splitId', '=', splitId)
+    .where((eb) => eb('g.invalidated', '=', eb.val(false)))
+    .select((eb) => [
+      'ps.leagueGameId',
+      'u.username',
+      'ps.riotPuuid',
+      'ps.riotIgn',
+      'ps.playerRole as role',
+      'ps.champId',
+      'ps.champName',
+      // team/opponent by side
+      sql<string | null>`
+          CASE WHEN ${eb.ref('ps.side')} = 'Blue' THEN ${eb.ref('tb.name')} ELSE ${eb.ref('tr.name')} END
+        `.as('teamName'),
+      sql<string | null>`
+          CASE WHEN ${eb.ref('ps.side')} = 'Blue' THEN ${eb.ref('tr.name')} ELSE ${eb.ref('tb.name')} END
+        `.as('opposingTeamName'),
+    ]);
+};
 
 export class PlayerStatsQuery {
   // -- INSERT
@@ -36,6 +87,80 @@ export class PlayerStatsQuery {
       .select('u.username as username')
       .where('ps.leagueGameId', '=', gameId)
       .execute();
+  }
+
+  // For PlayerStatRecord
+  static listCreepScorePerMinuteRecordsBySplitId(
+    splitId: string,
+  ): Promise<PlayerStatRecordCreepScorePerMinuteDto[]> {
+    return playerStatRecordBaseQuery(splitId)
+      .select(['ps.creepScorePerMinute', 'ps.creepScore'])
+      .orderBy('ps.creepScorePerMinute', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute();
+  }
+
+  static listDamageDealtPerMinuteRecordsBySplitId(
+    splitId: string,
+  ): Promise<PlayerStatRecordDamageDealtPerMinuteDto[]> {
+    return playerStatRecordBaseQuery(splitId)
+      .select([
+        'ps.damageDealtPerMinute',
+        'ps.totalDamageToChamps as damageDealt',
+      ])
+      .orderBy('ps.damageDealtPerMinute', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute();
+  }
+
+  static listVisionScorePerMinuteRecordsBySplitId(
+    splitId: string,
+  ): Promise<PlayerStatRecordVisionScorePerMinuteDto[]> {
+    return playerStatRecordBaseQuery(splitId)
+      .select(['ps.visionScorePerMinute', 'ps.visionScore'])
+      .orderBy('ps.visionScorePerMinute', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute() as Promise<PlayerStatRecordVisionScorePerMinuteDto[]>;
+  }
+
+  static listKillsAt15RecordsBySplitId(
+    splitId: string,
+  ): Promise<PlayerStatRecordKillsAt15Dto[]> {
+    return playerStatRecordBaseQuery(splitId)
+      .select('ps.killsAt15')
+      .orderBy('ps.killsAt15', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute() as Promise<PlayerStatRecordKillsAt15Dto[]>;
+  }
+
+  static listDamageAt15RecordsBySplitId(
+    splitId: string,
+  ): Promise<PlayerStatRecordDamageAt15Dto[]> {
+    return playerStatRecordBaseQuery(splitId)
+      .select(['ps.damageAt15', 'ps.damageDiff15'])
+      .orderBy('ps.damageAt15', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute() as Promise<PlayerStatRecordDamageAt15Dto[]>;
+  }
+
+  static listGoldAt15RecordsBySplitId(
+    splitId: string,
+  ): Promise<PlayerStatRecordGoldAt15Dto[]> {
+    return playerStatRecordBaseQuery(splitId)
+      .select(['ps.goldAt15', 'ps.goldDiff15'])
+      .orderBy('ps.goldAt15', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute() as Promise<PlayerStatRecordGoldAt15Dto[]>;
+  }
+
+  static listCsAt15RecordsBySplitId(
+    splitId: string,
+  ): Promise<PlayerStatRecordCsAt15Dto[]> {
+    return playerStatRecordBaseQuery(splitId)
+      .select(['ps.csAt15', 'ps.csDiff15'])
+      .orderBy('ps.csAt15', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute() as Promise<PlayerStatRecordCsAt15Dto[]>;
   }
 
   // -- UPDATE (not updateable)

--- a/src/database/tables/teamStats/teamStats.query.ts
+++ b/src/database/tables/teamStats/teamStats.query.ts
@@ -1,8 +1,52 @@
-import { TEAM_STATS, TEAMS } from '@/database/const.js';
+import { sql } from 'kysely';
+
+import {
+  LEAGUE_GAMES,
+  LEAGUE_MATCHES,
+  TEAM_STATS,
+  TEAMS,
+} from '@/database/const.js';
 import { db } from '@/database/database.js';
 import { type InsertTeamStat, type TeamStatRow } from '@/database/schema.js';
+import { RECORD_LIMIT } from '@/database/shared.js';
 import type { LeagueSide } from '@/database/shared.js';
 import type { GameTeamStatRow } from '@/router/game/v1/game.dto.js';
+import type {
+  TeamStatRecordDamageAt15Dto,
+  TeamStatRecordFirstBloodTimestampDto,
+  TeamStatRecordFirstInhibitorTimestampDto,
+  TeamStatRecordFirstTowerTimestampDto,
+  TeamStatRecordGoldAt15Dto,
+  TeamStatRecordKillsAt15Dto,
+  TeamStatRecordWardsClearedAt15Dto,
+  TeamStatRecordWardsPlacedAt15Dto,
+} from '@/router/split/v1/split.dto.js';
+
+/**
+ * Helper function to build the base query for team stat records (used in multiple places).
+ */
+const teamStatRecordBaseQuery = (splitId: string) => {
+  return db
+    .selectFrom(`${TEAM_STATS} as ts`)
+    .innerJoin(`${LEAGUE_GAMES} as g`, 'g.id', 'ts.leagueGameId')
+    .innerJoin(`${LEAGUE_MATCHES} as m`, 'm.id', 'g.leagueMatchId')
+    .leftJoin(`${TEAMS} as t`, 't.id', 'ts.teamId') // this team
+    .leftJoin(`${TEAMS} as tb`, 'tb.id', 'g.blueTeamId') // blue side in game
+    .leftJoin(`${TEAMS} as tr`, 'tr.id', 'g.redTeamId') // red side in game
+    .where('m.splitId', '=', splitId)
+    .where((eb) => eb('g.invalidated', '=', eb.val(false)))
+    .select((eb) => [
+      'ts.leagueGameId',
+      't.name as teamName',
+      // opponent name from side
+      sql<string>`
+        CASE 
+          WHEN ${eb.ref('ts.side')} = 'Blue' THEN ${eb.ref('tr.name')}
+          ELSE ${eb.ref('tb.name')}
+        END
+      `.as('opposingTeamName'),
+    ]);
+};
 
 export class TeamStatsQuery {
   // -- INSERT
@@ -33,6 +77,88 @@ export class TeamStatsQuery {
       .select('t.name as teamName')
       .where('ts.leagueGameId', '=', gameId)
       .orderBy('side', 'asc')
+      .execute();
+  }
+
+  // For TeamStatRecords
+
+  static listFirstTowerTimestampRecordsBySplitId(
+    splitId: string,
+  ): Promise<TeamStatRecordFirstTowerTimestampDto[]> {
+    return teamStatRecordBaseQuery(splitId)
+      .select('ts.firstTowerTimestamp')
+      .orderBy('ts.firstTowerTimestamp', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute();
+  }
+
+  static listFirstBloodTimestampRecordsBySplitId(
+    splitId: string,
+  ): Promise<TeamStatRecordFirstBloodTimestampDto[]> {
+    return teamStatRecordBaseQuery(splitId)
+      .select('ts.firstBloodTimestamp')
+      .orderBy('ts.firstBloodTimestamp', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute();
+  }
+
+  static listFirstInhibitorTimestampRecordsBySplitId(
+    splitId: string,
+  ): Promise<TeamStatRecordFirstInhibitorTimestampDto[]> {
+    return teamStatRecordBaseQuery(splitId)
+      .select('ts.firstInhibitorTimestamp')
+      .orderBy('ts.firstInhibitorTimestamp', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute();
+  }
+
+  static listKillsAt15RecordsBySplitId(
+    splitId: string,
+  ): Promise<TeamStatRecordKillsAt15Dto[]> {
+    return teamStatRecordBaseQuery(splitId)
+      .select(['ts.killsAt15', 'ts.killsDiff15'])
+      .orderBy('ts.killsAt15', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute();
+  }
+
+  static listGoldAt15RecordsBySplitId(
+    splitId: string,
+  ): Promise<TeamStatRecordGoldAt15Dto[]> {
+    return teamStatRecordBaseQuery(splitId)
+      .select(['ts.goldAt15', 'ts.goldDiff15'])
+      .orderBy('ts.goldAt15', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute();
+  }
+
+  static listDamageAt15RecordsBySplitId(
+    splitId: string,
+  ): Promise<TeamStatRecordDamageAt15Dto[]> {
+    return teamStatRecordBaseQuery(splitId)
+      .select(['ts.damageAt15', 'ts.damageDiff15'])
+      .orderBy('ts.damageAt15', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute();
+  }
+
+  static listWardsPlacedAt15RecordsBySplitId(
+    splitId: string,
+  ): Promise<TeamStatRecordWardsPlacedAt15Dto[]> {
+    return teamStatRecordBaseQuery(splitId)
+      .select(['ts.wardsPlacedAt15', 'ts.wardsPlacedDiff15'])
+      .orderBy('ts.wardsPlacedAt15', 'desc')
+      .limit(RECORD_LIMIT)
+      .execute();
+  }
+
+  static listWardsClearedAt15RecordsBySplitId(
+    splitId: string,
+  ): Promise<TeamStatRecordWardsClearedAt15Dto[]> {
+    return teamStatRecordBaseQuery(splitId)
+      .select(['ts.wardsClearedAt15', 'ts.wardsClearedDiff15'])
+      .orderBy('ts.wardsClearedAt15', 'desc')
+      .limit(RECORD_LIMIT)
       .execute();
   }
 

--- a/src/database/tables/teamStats/teamStats.schema.ts
+++ b/src/database/tables/teamStats/teamStats.schema.ts
@@ -45,8 +45,11 @@ export const teamStatRowSchema = z.strictObject({
   creepScorePerMinute: z.coerce.number().nullable(),
   visionScorePerMinute: z.coerce.number().nullable(),
   firstBlood: z.coerce.boolean().nullable(),
+  firstBloodTimestamp: z.coerce.number().int().nullable(),
   firstTower: z.coerce.boolean().nullable(),
+  firstTowerTimestamp: z.coerce.number().int().nullable(),
   firstInhibitor: z.coerce.boolean().nullable(),
+  firstInhibitorTimestamp: z.coerce.number().int().nullable(),
   firstDragon: z.coerce.boolean().nullable(),
   firstVoidgrub: z.coerce.boolean().nullable(),
   firstHerald: z.coerce.boolean().nullable(),
@@ -146,8 +149,11 @@ export const createTeamStatsTable = async (
       .addColumn('vision_score_per_minute', 'float4')
       // first objectives
       .addColumn('first_blood', 'boolean')
+      .addColumn('first_blood_timestamp', 'int4')
       .addColumn('first_tower', 'boolean')
+      .addColumn('first_tower_timestamp', 'int4')
       .addColumn('first_inhibitor', 'boolean')
+      .addColumn('first_inhibitor_timestamp', 'int4')
       .addColumn('first_dragon', 'boolean')
       .addColumn('first_voidgrub', 'boolean')
       .addColumn('first_herald', 'boolean')

--- a/src/router/split/v1/split.dto.ts
+++ b/src/router/split/v1/split.dto.ts
@@ -6,27 +6,153 @@ import type {
 } from '@/database/schema.js';
 
 // SplitDto
-export type SplitSidesStatsDto = {
-  numberBlueSides: number | null;
-  numberRedSides: number | null;
+export type SidesStatsDto = {
+  blueSides: number | null;
+  redSides: number | null;
 };
-export type SplitGameStatsDto = {
+export type DragonStatsDto = {
+  cloud: number | null;
+  ocean: number | null;
+  infernal: number | null;
+  mountain: number | null;
+  hextech: number | null;
+  chemtech: number | null;
+  elder: number | null;
+};
+type GameStatRecordBase = {
+  leagueGameId: string;
+  blueTeamName: string | null;
+  redTeamName: string | null;
   duration: number | null;
-  totalKills: number | null;
-  totalKillsAt15: number | null;
-  killsPerMinute: number | null;
-  damageToChampionsPerMinute: number | null;
+};
+export type GameStatRecordTotalKillsDto = GameStatRecordBase & {
+  totalKills: number;
+};
+export type GameStatRecordTotalKillsAt15Dto = GameStatRecordBase & {
+  killsAt15: number;
+};
+export type GameStatRecordCreepScorePerMinuteDto = GameStatRecordBase & {
+  creepScorePerMinute: number;
+};
+export type GameStatRecordGoldPerMinuteDto = GameStatRecordBase & {
+  goldPerMinute: number;
+};
+export type GameStatRecordDamagePerMinuteDto = GameStatRecordBase & {
+  damageDealtPerMinute: number;
+};
+export type GameStatRecordVisionScorePerMinuteDto = GameStatRecordBase & {
+  visionScorePerMinute: number;
+};
+type TeamStatRecordBase = {
+  leagueGameId: string;
+  teamName: string | null;
+  opposingTeamName: string | null;
+};
+export type TeamStatRecordFirstTowerTimestampDto = TeamStatRecordBase & {
+  firstTowerTimestamp: number | null;
+};
+export type TeamStatRecordFirstBloodTimestampDto = TeamStatRecordBase & {
+  firstBloodTimestamp: number | null;
+};
+export type TeamStatRecordFirstInhibitorTimestampDto = TeamStatRecordBase & {
+  firstInhibitorTimestamp: number | null;
+};
+export type TeamStatRecordKillsAt15Dto = TeamStatRecordBase & {
+  killsAt15: number | null;
+  killsDiff15: number | null;
+};
+export type TeamStatRecordGoldAt15Dto = TeamStatRecordBase & {
+  goldAt15: number | null;
+  goldDiff15: number | null;
+};
+export type TeamStatRecordDamageAt15Dto = TeamStatRecordBase & {
+  damageAt15: number | null;
+  damageDiff15: number | null;
+};
+export type TeamStatRecordWardsPlacedAt15Dto = TeamStatRecordBase & {
+  wardsPlacedAt15: number | null;
+  wardsPlacedDiff15: number | null;
+};
+export type TeamStatRecordWardsClearedAt15Dto = TeamStatRecordBase & {
+  wardsClearedAt15: number | null;
+  wardsClearedDiff15: number | null;
+};
+type PlayerStatRecordBase = {
+  leagueGameId: string;
+  username: string | null;
+  riotPuuid: string | null;
+  riotIgn: string | null;
+  role: string | null;
+  champId: number | null;
+  champName: string | null;
+  teamName: string | null;
+  opposingTeamName: string | null;
+};
+export type PlayerStatRecordCreepScorePerMinuteDto = PlayerStatRecordBase & {
+  creepScorePerMinute: number | null;
+  creepScore: number | null;
+};
+export type PlayerStatRecordDamageDealtPerMinuteDto = PlayerStatRecordBase & {
+  damageDealtPerMinute: number | null;
+  damageDealt: number | null;
+};
+export type PlayerStatRecordVisionScorePerMinuteDto = PlayerStatRecordBase & {
   visionScorePerMinute: number | null;
+  visionScore: number | null;
+};
+export type PlayerStatRecordKillsAt15Dto = PlayerStatRecordBase & {
+  killsAt15: number | null;
+};
+export type PlayerStatRecordDamageAt15Dto = PlayerStatRecordBase & {
+  damageAt15: number | null;
+  damageDiff15: number | null;
+};
+export type PlayerStatRecordGoldAt15Dto = PlayerStatRecordBase & {
+  goldAt15: number | null;
+  goldDiff15: number | null;
+};
+export type PlayerStatRecordCsAt15Dto = PlayerStatRecordBase & {
+  csAt15: number | null;
+  csDiff15: number | null;
 };
 export type SplitDto = {
   split: SplitRow;
   teams: TeamRow[];
   rosterRequests: RosterRequestRow[];
   emergencySubRequests: EmergencySubRequestRow[];
-  overallStats: {
-    sides: SplitSidesStatsDto;
-    games: SplitGameStatsDto[];
-  };
+  sideStats: SidesStatsDto | null;
+  dragonStats: DragonStatsDto | null;
+  gameStatRecords: {
+    totalKills: GameStatRecordTotalKillsDto[] | null;
+    totalKillsAt15: GameStatRecordTotalKillsAt15Dto[] | null;
+    creepScorePerMinute: GameStatRecordCreepScorePerMinuteDto[] | null;
+    goldPerMinute: GameStatRecordGoldPerMinuteDto[] | null;
+    damagePerMinute: GameStatRecordDamagePerMinuteDto[] | null;
+    visionScorePerMinute: GameStatRecordVisionScorePerMinuteDto[] | null;
+  } | null;
+  teamStatRecords: {
+    firstTowerTimestamp: TeamStatRecordFirstTowerTimestampDto[] | null;
+    firstBloodTimestamp: TeamStatRecordFirstBloodTimestampDto[] | null;
+    firstInhibitorTimestamp: TeamStatRecordFirstInhibitorTimestampDto[] | null;
+    killsAt15: TeamStatRecordKillsAt15Dto[] | null;
+    goldDiff15: TeamStatRecordGoldAt15Dto[] | null;
+    damageDiff15: TeamStatRecordDamageAt15Dto[] | null;
+    wardsPlacedDiff15: TeamStatRecordWardsPlacedAt15Dto[] | null;
+    wardsClearedDiff15: TeamStatRecordWardsClearedAt15Dto[] | null;
+  } | null;
+  playerStatRecords: {
+    creepScorePerMinute: PlayerStatRecordCreepScorePerMinuteDto[] | null;
+    damageDealtPerMinute: PlayerStatRecordDamageDealtPerMinuteDto[] | null;
+    visionScorePerMinute: PlayerStatRecordVisionScorePerMinuteDto[] | null;
+    damageAt15: PlayerStatRecordDamageAt15Dto[] | null;
+    goldAt15: PlayerStatRecordGoldAt15Dto[] | null;
+    csAt15: PlayerStatRecordCsAt15Dto[] | null;
+  } | null;
+};
+export type SplitRecordsDto = {
+  sides: SidesStatsDto;
+  games: GameStatRecordBase[];
+  players: PlayerStatRecordBase[];
 };
 
 // SplitTableDto

--- a/src/router/split/v1/split.service.ts
+++ b/src/router/split/v1/split.service.ts
@@ -1,8 +1,11 @@
 import {
   EmergencySubRequestsQuery,
+  LeagueGamesQuery,
+  PlayerStatsQuery,
   RosterRequestsQuery,
   SplitsQuery,
   TeamsQuery,
+  TeamStatsQuery,
 } from '@/database/query.js';
 import type { InsertSplit, UpdateSplit } from '@/database/schema.js';
 import type { SplitDto, SplitTableDto } from '@/router/split/v1/split.dto.js';
@@ -20,13 +23,11 @@ export class SplitService {
       teams: [],
       rosterRequests: [],
       emergencySubRequests: [],
-      overallStats: {
-        sides: {
-          numberBlueSides: null,
-          numberRedSides: null,
-        },
-        games: [],
-      },
+      sideStats: null,
+      dragonStats: null,
+      gameStatRecords: null,
+      teamStatRecords: null,
+      playerStatRecords: null,
     };
   };
 
@@ -44,20 +45,89 @@ export class SplitService {
     const getRosterRequests = await RosterRequestsQuery.listBySplitId(splitId);
     const getEmergencySubRequests =
       await EmergencySubRequestsQuery.listBySplitId(splitId);
+    const getSidesStats = await LeagueGamesQuery.selectSidesBySplitId(splitId);
+    const getDragonStats =
+      await LeagueGamesQuery.selectDragonsBySplitId(splitId);
+    const getSingleGameRecords = {
+      totalKills:
+        (await LeagueGamesQuery.listTotalKillsRecordsBySplitId(splitId)) ??
+        null,
+      totalKillsAt15:
+        (await LeagueGamesQuery.listTotalKillsAt15RecordsBySplitId(splitId)) ??
+        null,
+      creepScorePerMinute:
+        (await LeagueGamesQuery.listCreepScorePerMinuteRecordsBySplitId(
+          splitId,
+        )) ?? null,
+      goldPerMinute:
+        (await LeagueGamesQuery.listGoldPerMinuteRecordsBySplitId(splitId)) ??
+        null,
+      damagePerMinute:
+        (await LeagueGamesQuery.listDamagePerMinuteRecordsBySplitId(splitId)) ??
+        null,
+      visionScorePerMinute:
+        (await LeagueGamesQuery.listVisionScorePerMinuteRecordsBySplitId(
+          splitId,
+        )) ?? null,
+    };
+    const getTeamStatRecords = {
+      firstTowerTimestamp:
+        (await TeamStatsQuery.listFirstTowerTimestampRecordsBySplitId(
+          splitId,
+        )) ?? null,
+      firstBloodTimestamp:
+        (await TeamStatsQuery.listFirstBloodTimestampRecordsBySplitId(
+          splitId,
+        )) ?? null,
+      firstInhibitorTimestamp:
+        (await TeamStatsQuery.listFirstInhibitorTimestampRecordsBySplitId(
+          splitId,
+        )) ?? null,
+      killsAt15:
+        (await TeamStatsQuery.listKillsAt15RecordsBySplitId(splitId)) ?? null,
+      goldDiff15:
+        (await TeamStatsQuery.listGoldAt15RecordsBySplitId(splitId)) ?? null,
+      damageDiff15:
+        (await TeamStatsQuery.listDamageAt15RecordsBySplitId(splitId)) ?? null,
+      wardsPlacedDiff15:
+        (await TeamStatsQuery.listWardsPlacedAt15RecordsBySplitId(splitId)) ??
+        null,
+      wardsClearedDiff15:
+        (await TeamStatsQuery.listWardsClearedAt15RecordsBySplitId(splitId)) ??
+        null,
+    };
+    const getPlayerStatRecords = {
+      creepScorePerMinute:
+        (await PlayerStatsQuery.listCreepScorePerMinuteRecordsBySplitId(
+          splitId,
+        )) ?? null,
+      damageDealtPerMinute:
+        (await PlayerStatsQuery.listDamageDealtPerMinuteRecordsBySplitId(
+          splitId,
+        )) ?? null,
+      visionScorePerMinute:
+        (await PlayerStatsQuery.listVisionScorePerMinuteRecordsBySplitId(
+          splitId,
+        )) ?? null,
+      damageAt15:
+        (await PlayerStatsQuery.listDamageAt15RecordsBySplitId(splitId)) ??
+        null,
+      goldAt15:
+        (await PlayerStatsQuery.listGoldAt15RecordsBySplitId(splitId)) ?? null,
+      csAt15:
+        (await PlayerStatsQuery.listCsAt15RecordsBySplitId(splitId)) ?? null,
+    };
 
     return {
       split: getSplit,
       teams: getTeams,
       rosterRequests: getRosterRequests,
       emergencySubRequests: getEmergencySubRequests,
-      overallStats: {
-        // Implement in AEGIS-27
-        sides: {
-          numberBlueSides: null,
-          numberRedSides: null,
-        },
-        games: [],
-      },
+      sideStats: getSidesStats ?? null,
+      dragonStats: getDragonStats ?? null,
+      gameStatRecords: getSingleGameRecords ?? null,
+      teamStatRecords: getTeamStatRecords ?? null,
+      playerStatRecords: getPlayerStatRecords ?? null,
     };
   };
 


### PR DESCRIPTION
## Jira Ticket

- [AEGIS-27](https://aegisesports.atlassian.net/browse/AEGIS-27)

## Description

Displayed a comprehensive suite of of stat record when querying by split. The changes introduce structured data types for game, team, and player stat records, along with database queries to retrieve top performance records across multiple categories.

## Changes

- Replaces the basic overallStats structure with detailed stat tracking for sides, dragons, and various performance records.
  - Implements database queries to retrieve top 10 records for various game statistics grouped by split
- Adds timestamp tracking for first objectives (tower, blood, inhibitor) in team stats

## How to Test

1. Use the latest Postman Team configuration with the following steps:
  a. Create League
  b. Create Split
  c. Create Team (2x)
  d. Create Match
  e. Create Game (2x), use the following ids: NA1_5381358950, NA1_5381305948
2. Check to see if the numbers look normal. We'll verify correctness later.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tested locally
- [x] Updated Postman team workspace (if applicable)
- [x] Updated documentation (if applicable)
